### PR TITLE
README updates and typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,17 @@ Firecracker MicroVMs via the command line. This lets you run a fully
 functional Firecracker MicroVM, including console access, read/write
 access to filesystems, and network connectivity.
 
+Building
+---
+
+We use [go modules](https://github.com/golang/go/wiki/Modules), so you need to build with Go 1.11 or newer. `go build` or `make` should be sufficient to generate a working firectl binary.
+
 Usage
 ---
+
+You'll need to have a [firecracker](https://github.com/firecracker-microvm/firecracker) build, as well as an uncompressed Linux kernel image (`vmlinux`) and root filesystem image.
+
+By default, firectl searches `PATH` for the firecracker binary. The location of the kernel and filesystem image must be provided explicitly.
 
 ```
 Usage:
@@ -39,7 +48,7 @@ Example
 ---
 
 ```
-./cmd/firectl/firectl \
+firectl \
   --kernel=~/bin/vmlinux \
   --root-drive=/images/image-debootstrap.img -t \
   --cpu-template=T2 \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Application Options:
   -c, --ncpus=                  Number of CPUs (default: 1)
       --cpu-template=           Firecracker CPU Template (C3 or T2)
   -m, --memory=                 VM memory, in MiB (default: 512)
-      --metadata=               Firecracker Meatadata for MMDS (json)
+      --metadata=               Firecracker Metadata for MMDS (json)
   -l, --firecracker-log=        pipes the fifo contents to the specified file
   -d, --debug                   Enable debug output
   -h, --help                    Show usage

--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ type options struct {
 	FcCPUCount         int64    `long:"ncpus" short:"c" description:"Number of CPUs" default:"1"`
 	FcCPUTemplate      string   `long:"cpu-template" description:"Firecracker CPU Template (C3 or T2)"`
 	FcMemSz            int64    `long:"memory" short:"m" description:"VM memory, in MiB" default:"512"`
-	FcMetadata         string   `long:"metadata" description:"Firecracker Meatadata for MMDS (json)"`
+	FcMetadata         string   `long:"metadata" description:"Firecracker Metadata for MMDS (json)"`
 	FcFifoLogFile      string   `long:"firecracker-log" short:"l" description:"pipes the fifo contents to the specified file"`
 	Debug              bool     `long:"debug" short:"d" description:"Enable debug output"`
 	Help               bool     `long:"help" short:"h" description:"Show usage"`
@@ -249,7 +249,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Unable to parse NIC config: %s", err)
 		} else {
-			log.Error("Adding tap device %s", tapDev)
+			log.Errorf("Adding tap device %s", tapDev)
 			allowMDDS := metadata != nil
 			NICs = []firecracker.NetworkInterface{
 				firecracker.NetworkInterface{


### PR DESCRIPTION
Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

A couple of issues in README were missed in the migration of firectl to its own repository.

This also fixes some typos in `main.go`; no functionality is changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
