### PR TITLE
Modify makefile: firectl rule, add test/lint targets, fix lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ all: firectl
 firectl: $(SRCFILES)
 	go build
 
+test:
+	go test -v ./...
+
+lint:
+	golint $(SRCFILES)
+
 clean:
 	go clean
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+SRCFILES := *.go
 
 all: firectl
 
-firectl:
+firectl: $(SRCFILES)
 	go build
 
 clean:

--- a/errors.go
+++ b/errors.go
@@ -17,19 +17,19 @@ import "errors"
 
 var (
 	// Error parsing nic config
-	parseNicConfigError = errors.New("NIC config wasn't of the form DEVICE/MACADDR")
+	errInvalidNicConfig = errors.New("NIC config wasn't of the form DEVICE/MACADDR")
 
 	// error parsing blockdevices
-	invalidDriveSpecificationNoSuffix = errors.New("invalid drive specification. Must have :rw or :ro suffix")
-	invalidDriveSpecificationNoPath   = errors.New("invalid drive specification. Must have path")
+	errInvalidDriveSpecificationNoSuffix = errors.New("invalid drive specification. Must have :rw or :ro suffix")
+	errInvalidDriveSpecificationNoPath   = errors.New("invalid drive specification. Must have path")
 
 	// error parsing vsock
-	unableToParseVsockDevices = errors.New("unable to parse vsock devices")
-	unableToParseVsockCID     = errors.New("unable to parse vsock CID as a number")
+	errUnableToParseVsockDevices = errors.New("unable to parse vsock devices")
+	errUnableToParseVsockCID     = errors.New("unable to parse vsock CID as a number")
 
 	// error with handlefifos
-	conflictingLogOptsSet = errors.New("vmm-log-fifo and firecracker-log cannot be used together")
+	errConflictingLogOpts = errors.New("vmm-log-fifo and firecracker-log cannot be used together")
 
 	// error with firecracker config
-	invalidMetadata = errors.New("invalid metadata, unable to parse as json")
+	errInvalidMetadata = errors.New("invalid metadata, unable to parse as json")
 )

--- a/options_test.go
+++ b/options_test.go
@@ -49,7 +49,7 @@ func TestParseBlockDevices(t *testing.T) {
 			in:        []string{"/path"},
 			outDrives: nil,
 			expectedErr: func(a error) bool {
-				return a == invalidDriveSpecificationNoSuffix
+				return a == errInvalidDriveSpecificationNoSuffix
 			},
 		},
 		{
@@ -57,7 +57,7 @@ func TestParseBlockDevices(t *testing.T) {
 			in:        []string{":rw"},
 			outDrives: nil,
 			expectedErr: func(a error) bool {
-				return a == invalidDriveSpecificationNoPath
+				return a == errInvalidDriveSpecificationNoPath
 			},
 		},
 		{
@@ -113,21 +113,21 @@ func TestParseNicConfig(t *testing.T) {
 			in:        "a/",
 			outDevice: "",
 			outMac:    "",
-			outError:  parseNicConfigError,
+			outError:  errInvalidNicConfig,
 		},
 		{
 			name:      "no separater",
 			in:        "ab",
 			outDevice: "",
 			outMac:    "",
-			outError:  parseNicConfigError,
+			outError:  errInvalidNicConfig,
 		},
 		{
 			name:      "empty nic config",
 			in:        "",
 			outDevice: "",
 			outMac:    "",
-			outError:  parseNicConfigError,
+			outError:  errInvalidNicConfig,
 		},
 	}
 
@@ -181,7 +181,7 @@ func TestParseVsocks(t *testing.T) {
 			in:         []string{"a3:"},
 			outDevices: []firecracker.VsockDevice{},
 			expectedErr: func(a error) bool {
-				return a == unableToParseVsockDevices
+				return a == errUnableToParseVsockDevices
 			},
 		},
 		{
@@ -189,7 +189,7 @@ func TestParseVsocks(t *testing.T) {
 			in:         []string{""},
 			outDevices: []firecracker.VsockDevice{},
 			expectedErr: func(a error) bool {
-				return a == unableToParseVsockDevices
+				return a == errUnableToParseVsockDevices
 			},
 		},
 		{
@@ -197,7 +197,7 @@ func TestParseVsocks(t *testing.T) {
 			in:         []string{"a:b"},
 			outDevices: []firecracker.VsockDevice{},
 			expectedErr: func(a error) bool {
-				return a == unableToParseVsockCID
+				return a == errUnableToParseVsockCID
 			},
 		},
 		{
@@ -205,7 +205,7 @@ func TestParseVsocks(t *testing.T) {
 			in:         []string{"ae"},
 			outDevices: []firecracker.VsockDevice{},
 			expectedErr: func(a error) bool {
-				return a == unableToParseVsockDevices
+				return a == errUnableToParseVsockDevices
 			},
 		},
 	}
@@ -243,7 +243,7 @@ func TestHandleFifos(t *testing.T) {
 			},
 			outWriterNil: true,
 			expectedErr: func(e error) (bool, error) {
-				return e == conflictingLogOptsSet, conflictingLogOptsSet
+				return e == errConflictingLogOpts, errConflictingLogOpts
 			},
 			numClosers: 0,
 			validate:   validateTrue,
@@ -357,7 +357,7 @@ func TestGetFirecrackerNetworkingConfig(t *testing.T) {
 				FcNicConfig: "invalid",
 			},
 			expectedErr: func(e error) (bool, error) {
-				return e == parseNicConfigError, parseNicConfigError
+				return e == errInvalidNicConfig, errInvalidNicConfig
 			},
 			expectedNic: nil,
 		},
@@ -428,8 +428,8 @@ func TestGetBlockDevices(t *testing.T) {
 				FcAdditionalDrives: []string{"ab"},
 			},
 			expectedErr: func(e error) (bool, error) {
-				return e == invalidDriveSpecificationNoSuffix,
-					invalidDriveSpecificationNoSuffix
+				return e == errInvalidDriveSpecificationNoSuffix,
+					errInvalidDriveSpecificationNoSuffix
 			},
 			expectedDrives: nil,
 		},


### PR DESCRIPTION
*Description of changes:*
* Modifies the makefile so it will rebuild firectl if any *.go files have changed.
* Adds lint and test targets to makefile
* Fixes some small lint errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
