### PR TITLE
Add test for getFirecrackerConfig

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,8 +27,8 @@ var (
 	errUnableToParseVsockDevices = errors.New("unable to parse vsock devices")
 	errUnableToParseVsockCID     = errors.New("unable to parse vsock CID as a number")
 
-	// error with handlefifos
-	errConflictingLogOpts = errors.New("vmm-log-fifo and firecracker-log cannot be used together")
+	errConflictingLogOpts        = errors.New("vmm-log-fifo and firecracker-log cannot be used together")
+	errUnableToCreateFifoLogFile = errors.New("failed to create fifo log file")
 
 	// error with firecracker config
 	errInvalidMetadata = errors.New("invalid metadata, unable to parse as json")

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/firecracker-microvm/firectl
 require (
 	github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20181220230332-433f262dc33b
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.1.1 h1:VzGj7lhU7KEB9e9gMpAV/v5XT2NVSvLJhJLCWbnkgXg=

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ const (
 )
 
 func main() {
-	opts := options{}
+	opts := newOptions()
 	p := flags.NewParser(&opts, flags.Default)
 	// if no args just print help
 	if len(os.Args) == 1 {
@@ -66,7 +66,7 @@ func main() {
 }
 
 // Run a vmm with a given set of options
-func runVMM(ctx context.Context, opts options) error {
+func runVMM(ctx context.Context, opts *options) error {
 	// convert options to a firecracker config
 	fcCfg, err := opts.getFirecrackerConfig()
 	if err != nil {


### PR DESCRIPTION
*Description of changes:*
Add tests for getFirecrackerConfig() just as a quick sanity check that it is handling errors from other parsing functions correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
