### PR TITLE
add socket-path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ By default, firectl searches `PATH` for the firecracker binary. The location of 
 
 ```
 Usage:
-  firectl
+  firectl [OPTIONS]
 
 Application Options:
       --firecracker-binary=     Path to firecracker binary
@@ -40,8 +40,11 @@ Application Options:
   -m, --memory=                 VM memory, in MiB (default: 512)
       --metadata=               Firecracker Metadata for MMDS (json)
   -l, --firecracker-log=        pipes the fifo contents to the specified file
+  -s, --socket-path=            path to use for firecracker socket, defaults to a unique file in in the first existing directory from {$HOME, $TMPDIR, or /tmp}
   -d, --debug                   Enable debug output
-  -h, --help                    Show usage
+
+Help Options:
+  -h, --help                    Show this help message
 ```
 
 Example

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ const (
 
 func main() {
 	opts := newOptions()
-	p := flags.NewParser(&opts, flags.Default)
+	p := flags.NewParser(opts, flags.Default)
 	// if no args just print help
 	if len(os.Args) == 1 {
 		p.WriteHelp(os.Stderr)


### PR DESCRIPTION
*Issue #, if available:*
#3 
*Description of changes:*

adds a flag (-s, --socket-path) to configure the firecracker socket path. Defaults to a file in os.TempDir()/firecracker-socket*random numbers* if unspecified.

Also updated the README.md USAGE to match the actual usage.

*Testing done:*

Tested launching a vmm with firecracker v0.12.0 both with a socket-path specified and none specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
