### PR TITLE
Add Docker rule to Makefile, update build documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ firectl: $(SRCFILES)
 	go build
 
 docker:
-        docker run --rm -v ${PWD}:/go/bin golang go get github.com/firecracker-microvm/firectl/...
+        docker run --rm -v ${PWD}:/firectl --workdir /firectl golang:1.11 make
 
 test:
 	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ _We use [go modules](https://github.com/golang/go/wiki/Modules), so you need to 
 
 #### Make
 `make` is a Makefile rule which executes `go build`
+
 `make docker` creates a temporary Docker container which builds and copies the binary to your current directory.
 #### Docker
 `docker run --rm -v ${PWD}:/go/bin golang go get github.com/firecracker-microvm/firectl/...` creates a temporary Docker container which builds and copies the binary to your current directory.
 #### Go
-go build
+`go build`
 
 Usage
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There are a few methods for building the binary.
 _We use [go modules](https://github.com/golang/go/wiki/Modules), so you need to build with Go 1.11 or newer._
 
 #### Make
-`make` is a Makefile rule which executes `go build`
+The default Makefile rule executes `go build` and relies on the Go toolchain installed on your computer.
 
 `make docker` creates a temporary Docker container which builds and copies the binary to your current directory.
 #### Docker


### PR DESCRIPTION
*Description of changes:*
1. Added a Docker rule to the Makefile for users without Go locally installed.
2. Updated build documentation to reflect the options available for building.
3. Added explicit instructions for the build options.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.