### PR TITLE
WIP: Update for SDK interface changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,10 +114,7 @@ func runVMM(ctx context.Context, opts *options) error {
 		machineOpts = append(machineOpts, firecracker.WithProcessRunner(cmd))
 	}
 
-	m, err := firecracker.NewMachine(vmmCtx, fcCfg, machineOpts...)
-	if err != nil {
-		return fmt.Errorf("Failed creating machine: %s", err)
-	}
+	m := firecracker.NewMachine(vmmCtx, fcCfg, machineOpts...)
 
 	if opts.validMetadata != nil {
 		m.EnableMetadata(opts.validMetadata)

--- a/options.go
+++ b/options.go
@@ -119,7 +119,8 @@ func (opts *options) getFirecrackerConfig() (firecracker.Config, error) {
 			HtEnabled:   !opts.FcDisableHt,
 			MemSizeMib:  opts.FcMemSz,
 		},
-		Debug: opts.Debug,
+		DisableJailer: true,
+		Debug:         opts.Debug,
 	}, nil
 }
 


### PR DESCRIPTION
The Firecracker Go SDK enables the jailer by default in [pr 42](https://github.com/firecracker-microvm/firecracker-go-sdk/pull/42), but it requires some configuration. Until we have a plan for how to provide that configuration, let's disable the jailer by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
