### PR TITLE
Fix firecracker command builder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/firecracker-microvm/firectl
 
 require (
-	github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20181220230332-433f262dc33b
+	github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190226020201-847e85db1412
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20181220230332-433f262dc33b h1:5vIdzbfLuWaResxGLVzoNbpg2LEjSkEzDoJLJpqJqeE=
 github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20181220230332-433f262dc33b/go.mod h1:7ZuTUkeKoyUmdR6Tn4eepqjYeKMXcOg9gJytYVz8TuE=
+github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190226020201-847e85db1412 h1:RwIr6dztoblljoWEcoQJ26LATycGTrgSZg+/NJYMzrM=
+github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190226020201-847e85db1412/go.mod h1:UOsA6IaI52MQntB9PrarJFReY1nA9iZg2DI04kxPNMY=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb h1:D4uzjWwKYQ5XnAvUbuvHW93esHg7F8N/OYeBBcJoTr0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=

--- a/options.go
+++ b/options.go
@@ -130,12 +130,12 @@ func (opts *options) getNetwork() ([]firecracker.NetworkInterface, error) {
 		if err != nil {
 			return nil, err
 		}
-		allowMDDS := opts.validMetadata != nil
+		allowMMDS := opts.validMetadata != nil
 		NICs = []firecracker.NetworkInterface{
 			firecracker.NetworkInterface{
 				MacAddress:  tapMacAddr,
 				HostDevName: tapDev,
-				AllowMDDS:   allowMDDS,
+				AllowMMDS:   allowMMDS,
 			},
 		}
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -503,7 +503,7 @@ func TestGetFirecrackerNetworkingConfig(t *testing.T) {
 			expectedNic: nil,
 		},
 		{
-			name: "valid FcNicConfig with mdds set to true",
+			name: "valid FcNicConfig with MMDS set to true",
 			opt: options{
 				FcNicConfig:   "valid/things",
 				validMetadata: 42,
@@ -515,12 +515,12 @@ func TestGetFirecrackerNetworkingConfig(t *testing.T) {
 				firecracker.NetworkInterface{
 					MacAddress:  "things",
 					HostDevName: "valid",
-					AllowMDDS:   true,
+					AllowMMDS:   true,
 				},
 			},
 		},
 		{
-			name: "valid FcNicConfig with mdds set to false",
+			name: "valid FcNicConfig with MMDS set to false",
 			opt: options{
 				FcNicConfig: "valid/things",
 			},
@@ -531,7 +531,7 @@ func TestGetFirecrackerNetworkingConfig(t *testing.T) {
 				firecracker.NetworkInterface{
 					MacAddress:  "things",
 					HostDevName: "valid",
-					AllowMDDS:   false,
+					AllowMMDS:   false,
 				},
 			},
 		},


### PR DESCRIPTION
Addresses #22 

This change removes a conditional around the handling of the `--firecracker-binary` commandline flag such that the construction of the firecracker process commandline happens consistently whether the binary is provided explicitly or found via the PATH.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
