### PR TITLE
Update for Firecracker 0.17.0 SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/firecracker-microvm/firectl
 
 require (
-	github.com/firecracker-microvm/firecracker-go-sdk v0.15.1
+	github.com/firecracker-microvm/firecracker-go-sdk v0.15.2-0.20190627223500-b2e8284e890c
+	github.com/go-openapi/strfmt v0.17.1
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -7,14 +7,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20181220230332-433f262dc33b h1:5vIdzbfLuWaResxGLVzoNbpg2LEjSkEzDoJLJpqJqeE=
-github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20181220230332-433f262dc33b/go.mod h1:7ZuTUkeKoyUmdR6Tn4eepqjYeKMXcOg9gJytYVz8TuE=
-github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190226020201-847e85db1412 h1:RwIr6dztoblljoWEcoQJ26LATycGTrgSZg+/NJYMzrM=
-github.com/firecracker-microvm/firecracker-go-sdk v0.0.0-20190226020201-847e85db1412/go.mod h1:UOsA6IaI52MQntB9PrarJFReY1nA9iZg2DI04kxPNMY=
-github.com/firecracker-microvm/firecracker-go-sdk v0.15.1-0.20190301211204-479ac1377a66 h1:VyaTvfeBlTquUvE8S4OlYydnjNeESYxHJFZs6LCDTSo=
-github.com/firecracker-microvm/firecracker-go-sdk v0.15.1-0.20190301211204-479ac1377a66/go.mod h1:UOsA6IaI52MQntB9PrarJFReY1nA9iZg2DI04kxPNMY=
-github.com/firecracker-microvm/firecracker-go-sdk v0.15.1 h1:xtNAtwXMKXctB/CMn8tdTfpEzfqPUfqm7+Y3pYUSYZc=
-github.com/firecracker-microvm/firecracker-go-sdk v0.15.1/go.mod h1:QcNsz2gYkcTI/zAQl3dYeLwf7KxtjKnt7aGklhn9yYk=
+github.com/firecracker-microvm/firecracker-go-sdk v0.15.2-0.20190627223500-b2e8284e890c h1:jAAxKV5SD/y2nNKNLHgAUmfgbrvfN4xBiKR+b2qK2pM=
+github.com/firecracker-microvm/firecracker-go-sdk v0.15.2-0.20190627223500-b2e8284e890c/go.mod h1:QcNsz2gYkcTI/zAQl3dYeLwf7KxtjKnt7aGklhn9yYk=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb h1:D4uzjWwKYQ5XnAvUbuvHW93esHg7F8N/OYeBBcJoTr0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
@@ -43,8 +37,6 @@ github.com/go-openapi/swag v0.17.1/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/validate v0.17.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.17.1 h1:RfQTLHm/gEu0oSUmbTOy0PMufjkE5/pPfnqYpor3WLc=
 github.com/go-openapi/validate v0.17.1/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
-github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
-github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func runVMM(ctx context.Context, opts *options) error {
 	}
 
 	if opts.validMetadata != nil {
-		m.EnableMetadata(opts.validMetadata)
+		m.SetMetadata(vmmCtx, opts.validMetadata)
 	}
 
 	if err := m.Start(vmmCtx); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -106,8 +106,8 @@ func TestFireCTL(t *testing.T) {
 		}
 
 		payload = resp.Payload
-		if len(resp.Payload.State) != 0 &&
-			payload.State != models.InstanceInfoStateUninitialized {
+		if len(*resp.Payload.State) != 0 &&
+			*payload.State != models.InstanceInfoStateUninitialized {
 			valid = true
 			break
 		}
@@ -116,6 +116,6 @@ func TestFireCTL(t *testing.T) {
 	}
 
 	if !valid {
-		t.Errorf("VM failed to initialize with last state of %q. Can firecracker successfully launch a VM?", payload.State)
+		t.Errorf("VM failed to initialize with last state of %q. Can firecracker successfully launch a VM?", *payload.State)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -103,6 +103,8 @@ func (opts *options) getFirecrackerConfig() (firecracker.Config, error) {
 		socketPath = getSocketPath()
 	}
 
+	htEnabled := !opts.FcDisableHt
+
 	return firecracker.Config{
 		SocketPath:        socketPath,
 		LogFifo:           opts.FcLogFifo,
@@ -115,10 +117,10 @@ func (opts *options) getFirecrackerConfig() (firecracker.Config, error) {
 		NetworkInterfaces: NICs,
 		VsockDevices:      vsocks,
 		MachineCfg: models.MachineConfiguration{
-			VcpuCount:   opts.FcCPUCount,
+			VcpuCount:   firecracker.Int64(opts.FcCPUCount),
 			CPUTemplate: models.CPUTemplate(opts.FcCPUTemplate),
-			HtEnabled:   !opts.FcDisableHt,
-			MemSizeMib:  opts.FcMemSz,
+			HtEnabled:   firecracker.Bool(htEnabled),
+			MemSizeMib:  firecracker.Int64(opts.FcMemSz),
 		},
 		Debug: opts.Debug,
 	}, nil

--- a/options_test.go
+++ b/options_test.go
@@ -118,7 +118,9 @@ func TestGetFirecrackerConfig(t *testing.T) {
 					},
 				},
 				MachineCfg: models.MachineConfiguration{
-					HtEnabled: true,
+					VcpuCount:  firecracker.Int64(0),
+					MemSizeMib: firecracker.Int64(0),
+					HtEnabled:  firecracker.Bool(true),
 				},
 			},
 		},
@@ -141,7 +143,9 @@ func TestGetFirecrackerConfig(t *testing.T) {
 					},
 				},
 				MachineCfg: models.MachineConfiguration{
-					HtEnabled: true,
+					VcpuCount:  firecracker.Int64(0),
+					MemSizeMib: firecracker.Int64(0),
+					HtEnabled:  firecracker.Bool(true),
 				},
 			},
 		},


### PR DESCRIPTION
This change depends on firecracker-microvm/firecracker-go-sdk#101 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
