### PR TITLE
Minor makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 build-in-docker:
-	docker run --rm -v ${PWD}:/firectl --workdir /firectl golang:1.12 make
+	docker run --rm -v $(CURDIR):/firectl --workdir /firectl golang:1.12 make
 
 test:
 	go test -v ./...
@@ -45,4 +45,4 @@ clean:
 install:
 	install -o root -g root -m755 firectl $(BINDIR)/
 
-.PHONY: all clean install
+.PHONY: all clean install build-in-docker test lint release


### PR DESCRIPTION
Set several targets as .PHONY

Use CURDIR instead of PWD when referncing the current working directory. The
former is managed by make itself, while the latter comes from the shell and
does not reflect the current directory in "make -C some/other/directory"
scenarios.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
