### PR TITLE
firectl: add metadata after VM has been started

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,14 +127,14 @@ func runVMM(ctx context.Context, opts *options) error {
 		return fmt.Errorf("Failed creating machine: %s", err)
 	}
 
-	if opts.validMetadata != nil {
-		m.SetMetadata(vmmCtx, opts.validMetadata)
-	}
-
 	if err := m.Start(vmmCtx); err != nil {
 		return fmt.Errorf("Failed to start machine: %v", err)
 	}
 	defer m.StopVMM()
+
+	if opts.validMetadata != nil {
+		m.SetMetadata(vmmCtx, opts.validMetadata)
+	}
 
 	installSignalHandlers(vmmCtx, m)
 


### PR DESCRIPTION
This is a small change that has `firectl` add the VM Metadata after the VM has been started. Using the latest version from master, I was reliably able to reproduce:

```
ERRO[0000] Setting metadata: Put http://localhost/mmds: dial unix /home/nick/.firecracker.sock-11716-81: connect: no such file or directory
```

with a basic

```
--metadata='{"latest": { "meta-data": { "test": "12345" } } }'
```

I believe this ordering is necessary, as there is no running/listening firecracker socket to add the metadata to before this step, causing `firectl` to fail 100% of the time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
