### PR TITLE
Update version to 0.19.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,8 @@ func main() {
 	}
 
 	if opts.Version {
-		fmt.Println(Version)
+		fmt.Println("Version:", Version)
+		fmt.Println("SupportedFirecrackerVersion:", SupportedFirecrackerVersion)
 		os.Exit(0)
 	}
 

--- a/version.go
+++ b/version.go
@@ -16,3 +16,6 @@ package main
 // Version represents the major, minor, and patch version of
 // FireCTL.
 const Version = "0.1.0"
+
+// SupportedFirecrackerVersion is the firecracker version that the sdk
+const SupportedFirecrackerVersion = "0.19.0"


### PR DESCRIPTION
*Description of changes:*
Makes firectl --version output 0.19.0 to match the firecracker version it will work with.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
