### PR TITLE
Building firectl requires at least Go 1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 build-in-docker:
-	docker run --rm -v $(CURDIR):/firectl --workdir /firectl golang:1.12 make
+	docker run --rm -v $(CURDIR):/firectl --workdir /firectl golang:1.14 make
 
 test:
 	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Building
 The default Makefile rule executes `go build` and relies on the Go toolchain
 installed on your computer.
 _We use [go modules](https://github.com/golang/go/wiki/Modules), so you need to
-build with Go 1.11 or newer._
+build with Go 1.14 or newer._
 
 If you do not have a new-enough Go toolchain installed, you can use `make
 build-in-docker`.  This rule creates a temporary Docker container which builds


### PR DESCRIPTION
It looks like building `firectl` requiers at least Go 1.14. Othwise I get the following build error:
```
$ make build-in-docker
docker run --rm -v /priv/simonisv/OpenJDK/Git/firectl:/firectl --workdir /firectl golang:1.12 make
Unable to find image 'golang:1.12' locally
1.12: Pulling from library/golang
...
# github.com/hashicorp/go-multierror
/go/pkg/mod/github.com/hashicorp/go-multierror@v1.1.0/multierror.go:112:9: undefined: errors.As
/go/pkg/mod/github.com/hashicorp/go-multierror@v1.1.0/multierror.go:117:9: undefined: errors.Is
note: module requires Go 1.14
make: *** [Makefile:30: firectl] Error 2
```

The fix is  trivial. I've updated the `Makefile` and `Readme.md` to use the new version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
