### PR TITLE
installSignalHandlers: fix signal names in logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,10 +161,10 @@ func installSignalHandlers(ctx context.Context, m *firecracker.Machine) {
 		for {
 			switch s := <-c; {
 			case s == syscall.SIGTERM || s == os.Interrupt:
-				log.Printf("Caught SIGINT, requesting clean shutdown")
+				log.Printf("Caught signal: %s, requesting clean shutdown", s.String())
 				m.Shutdown(ctx)
 			case s == syscall.SIGQUIT:
-				log.Printf("Caught SIGTERM, forcing shutdown")
+				log.Printf("Caught signal: %s, forcing shutdown", s.String())
 				m.StopVMM()
 			}
 		}


### PR DESCRIPTION
*Description of changes:*

I'm not sure if this is an oversight or if this is intentional.

That being said, If run:

-  ✅ `killall -s SIGINT firectl`, it prints `INFO[0009] Caught SIGINT, requesting clean shutdown`
- ❌ `killall -s SIGTERM firectl`, it prints `INFO[0009] Caught SIGINT, requesting clean shutdown`
- ❌ `killall -s SIGQUIT firectl`, it prints `INFO[0012] Caught SIGTERM, forcing shutdown`

I replaced them with `s.String()` instead 🤔 


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
