### PR TITLE
Use clean checkouts to avoid tests failing due to left over symlinks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,6 +18,8 @@ env:
   FIRECRACKER_VERSION: 0.19.0
   # Firecracker binaries will be installed and run from this directory:
   BINDIR: "${PWD}-bin"
+  # Perform a clean checkout to ensure symlinks are gone
+  BUILDKITE_CLEAN_CHECKOUT: true
 
 steps:
   - label: ':go: go mod download'


### PR DESCRIPTION
Buildkite reuses the build directory between runs on the same agent. When a build lands on a host that has already done a build at some point in the past, it fails because it tries to recreate the bin symlinks. We should start each build from a clean slate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
