### PR TITLE
Use Go 1.15 and Firecracker 0.25.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@
 
 env:
   # The CI system uses Debian 10 with go from stable backports:
-  PATH: "/usr/lib/go-1.13/bin:/usr/bin"
+  PATH: "/usr/lib/go-1.15/bin:/usr/bin"
   # Firectl tests will run against this version of firecracker:
   FIRECRACKER_VERSION: 0.19.0
   # Firecracker binaries will be installed and run from this directory:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ env:
   # The CI system uses Debian 10 with go from stable backports:
   PATH: "/usr/lib/go-1.15/bin:/usr/bin"
   # Firectl tests will run against this version of firecracker:
-  FIRECRACKER_VERSION: 0.19.0
+  FIRECRACKER_VERSION: 0.25.2
   # Firecracker binaries will be installed and run from this directory:
   BINDIR: "${PWD}-bin"
   # Perform a clean checkout to ensure symlinks are gone


### PR DESCRIPTION
The host no longer have Go 1.13.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
