### PR TITLE
add initrd option

### DIFF
--- a/options.go
+++ b/options.go
@@ -40,6 +40,7 @@ type options struct {
 	FcBinary           string   `long:"firecracker-binary" description:"Path to firecracker binary"`
 	FcKernelImage      string   `long:"kernel" description:"Path to the kernel image" default:"./vmlinux"`
 	FcKernelCmdLine    string   `long:"kernel-opts" description:"Kernel commandline" default:"ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules"`
+	FcInitrdPath       string   `long:"initrd-path" description:"path to initrd" default:"./initramfs"`
 	FcRootDrivePath    string   `long:"root-drive" description:"Path to root disk image"`
 	FcRootPartUUID     string   `long:"root-partition" description:"Root partition UUID"`
 	FcAdditionalDrives []string `long:"add-drive" description:"Path to additional drive, suffixed with :ro or :rw, can be specified multiple times"`
@@ -146,6 +147,7 @@ func (opts *options) getFirecrackerConfig() (firecracker.Config, error) {
 		FifoLogWriter:     fifo,
 		KernelImagePath:   opts.FcKernelImage,
 		KernelArgs:        opts.FcKernelCmdLine,
+		InitrdPath:        opts.FcInitrdPath,
 		Drives:            blockDevices,
 		NetworkInterfaces: NICs,
 		VsockDevices:      vsocks,

--- a/options.go
+++ b/options.go
@@ -40,7 +40,7 @@ type options struct {
 	FcBinary           string   `long:"firecracker-binary" description:"Path to firecracker binary"`
 	FcKernelImage      string   `long:"kernel" description:"Path to the kernel image" default:"./vmlinux"`
 	FcKernelCmdLine    string   `long:"kernel-opts" description:"Kernel commandline" default:"ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules"`
-	FcInitrdPath       string   `long:"initrd-path" description:"path to initrd" default:"./initramfs"`
+	FcInitrd           string   `long:"initrd-path" description:"Path to initrd"`
 	FcRootDrivePath    string   `long:"root-drive" description:"Path to root disk image"`
 	FcRootPartUUID     string   `long:"root-partition" description:"Root partition UUID"`
 	FcAdditionalDrives []string `long:"add-drive" description:"Path to additional drive, suffixed with :ro or :rw, can be specified multiple times"`
@@ -147,7 +147,7 @@ func (opts *options) getFirecrackerConfig() (firecracker.Config, error) {
 		FifoLogWriter:     fifo,
 		KernelImagePath:   opts.FcKernelImage,
 		KernelArgs:        opts.FcKernelCmdLine,
-		InitrdPath:        opts.FcInitrdPath,
+		InitrdPath:        opts.FcInitrd,
 		Drives:            blockDevices,
 		NetworkInterfaces: NICs,
 		VsockDevices:      vsocks,


### PR DESCRIPTION
Signed-off-by: Michael Coulter <mjc@sekurity.org>

This adds an option to specify an initrd for firecracker via `--initrd-path`.

Not sure if the default is what's preferred or if some tests need to be added, but this was enough to be useful my own use case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
