### PR TITLE
Remove io/ioutil package dependency

### DIFF
--- a/options.go
+++ b/options.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -244,7 +243,7 @@ func (opts *options) handleFifos() (io.Writer, error) {
 	}
 
 	if generateFifoFilename || generateMetricFifoFilename {
-		dir, err := ioutil.TempDir(os.TempDir(), "fcfifo")
+		dir, err := os.MkdirTemp("", "fcfifo")
 		if err != nil {
 			return fifo, fmt.Errorf("Fail to create temporary directory: %v", err)
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -14,7 +14,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -25,7 +24,7 @@ import (
 )
 
 func TestGetFirecrackerConfig(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "firectl-test-drive-path")
+	tempFile, err := os.CreateTemp("", "firectl-test-drive-path")
 	if err != nil {
 		t.Error(err)
 	}
@@ -209,7 +208,7 @@ func TestParseDevice(t *testing.T) {
 }
 
 func TestParseBlockDevices(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "firectl-test-drive-path")
+	tempFile, err := os.CreateTemp("", "firectl-test-drive-path")
 	if err != nil {
 		t.Error(err)
 	}
@@ -628,7 +627,7 @@ func TestGetFirecrackerNetworkingConfig(t *testing.T) {
 }
 
 func TestGetBlockDevices(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "firectl-test-drive-path")
+	tempFile, err := os.CreateTemp("", "firectl-test-drive-path")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Package io/ioutil deprecated since Go 1.16
Reference: https://go.dev/doc/go1.16#ioutil

Requires #93 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>