### PR TITLE
Disable simultaneous multithreading for arm64

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,7 +66,7 @@ steps:
       # ensures that firectl is tested in its common configuration, in
       # which it isn't explicitly given a path to a binary but uses
       # PATH resolution to find it.
-      - "mkdir \"${BINDIR}\""
+      - "mkdir -p \"${BINDIR}\""
       - "ln -s -v /usr/local/bin/firecracker-v${FIRECRACKER_VERSION} \"${BINDIR}/firecracker\""
       - "ln -s -v \"/usr/local/bin/jailer-v${FIRECRACKER_VERSION}\" \"${BINDIR}/jailer\""
       - "KERNELIMAGE=/var/lib/fc-ci/vmlinux.bin PATH=\"${BINDIR}:${PATH}\" make all test"

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"syscall"
 	"testing"
+	"runtime"
 	"time"
 
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
@@ -72,6 +73,11 @@ func TestFireCTL(t *testing.T) {
 		"--root-drive",
 		rootDrivePath,
 	}
+
+	if runtime.GOARCH == "arm64" {
+		firectlArgs = append(firectlArgs, "--disable-smt") // Disable simultaneous multithreading is supported by aarch64
+	}
+
 	cmd := exec.CommandContext(ctlCtx, firectlName, firectlArgs...)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Failed to run command: %v", err)


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue:* Enabling simultaneous multithreading is not supported on aarch64 testing is occurring while ARM instance is testing against firectl by creating a BuildKite pipeline.

*Description of changes:* To support ARM architecture, disable the simultaneous multithreading. Using GOARCH to target the 'arm64' architecture.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
