### PR TITLE
README instructions are outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ Getting Started on AWS
 - Get firectl binary:
 
   ```
-  curl -Lo firectl https://firectl-release.s3.amazonaws.com/firectl-v0.1.0
-  curl -Lo firectl.sha256 https://firectl-release.s3.amazonaws.com/firectl-v0.1.0.sha256
+  curl -Lo firectl-v0.2.0 https://github.com/firecracker-microvm/firectl/releases/download/v0.2.0/firectl-v0.2.0
+  curl -Lo firectl.sha256 https://github.com/firecracker-microvm/firectl/releases/download/v0.2.0/firectl-v0.2.0.sha256
   sha256sum -c firectl.sha256
+  mv firectl-v0.2.0 firectl
   chmod +x firectl
   ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ Getting Started on AWS
 - Get Firecracker binary:
 
   ```
-  curl -Lo firecracker https://github.com/firecracker-microvm/firecracker/releases/download/v0.16.0/firecracker-v0.16.0
+  curl -Lo firecracker.tgz https://github.com/firecracker-microvm/firecracker/releases/download/v1.1.2/firecracker-v1.1.2-x86_64.tgz
+  tar -xvf firecracker.tgz
+  mv release-v1.1.2-x86_64/firecracker-v1.1.2-x86_64 firecracker
+  rm -rf firecracker.tgz release-v1.1.2-x86_64
   chmod +x firecracker
   sudo mv firecracker /usr/local/bin/firecracker
   ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I'm not sure if these are the exact instructions that should be in the README. Instead, they're the commands that worked for me to get the latest versions of both firectl and firecracker.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
