### PR TITLE
Update Slack URL to a non-expired one

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ GitHub issues, but instead follow
 [Firecracker's security reporting guidelines](https://github.com/firecracker-microvm/firecracker/blob/main/SECURITY.md).
 
 Other discussion: For general discussion, please join us in the
-`#general` channel on the [Firecracker Slack](https://tinyurl.com/firecracker-microvm).
+`#general` channel on the [Firecracker Slack](https://join.slack.com/t/firecracker-microvm/shared_invite/zt-1fecwrorm-x5URTlOzBR2fExTU2mWfug).


### PR DESCRIPTION
*Description of changes:*

Updated the Slack URL in the `README.md` away from a URL shortened one that redirected to an expired invite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
