### PR TITLE
Upgrade go version used in buildkite from 1.15 to 1.17

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@
 
 env:
   # The CI system uses Debian 10 with go from stable backports:
-  PATH: "/usr/lib/go-1.15/bin:/usr/bin"
+  PATH: "/usr/lib/go-1.17/bin:/usr/bin"
   # Firectl tests will run against this version of firecracker:
   FIRECRACKER_VERSION: 1.0.0
   # Firecracker binaries will be installed and run from this directory:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.14', '1.15', '1.16']
+        go: ['1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20']
         os: ['ubuntu-20.04']
 
     name: ${{ matrix.os }} / Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(BINPATH)/git-validation:
 	fi
 
 $(BINPATH)/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BINPATH) v1.46.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(BINPATH) v1.53.3
 	$(BINPATH)/golangci-lint --version
 
 lint: $(BINPATH)/ltag $(BINPATH)/git-validation $(BINPATH)/golangci-lint


### PR DESCRIPTION

*Issue #, if available:*
CI is [failing](https://buildkite.com/firecracker-microvm/firectl/builds/335#01894246-7183-463f-9621-d3c61141e335) due to go version upgrade from to 1.15 to 1.17 in the build environment. 


*Description of changes:*
Change go PATH from 1.15 to 1.17 to align with [go version change](https://github.com/firecracker-microvm/firecracker-go-sdk/pull/498) in the build environment to fix build issue.  

Add support of go 1.17, 1.18, 1.19, 1.20. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
