### PR TITLE
Add cgroups-version option

### DIFF
--- a/options.go
+++ b/options.go
@@ -58,9 +58,10 @@ type options struct {
 	Debug              bool     `long:"debug" short:"d" description:"Enable debug output"`
 	Version            bool     `long:"version" description:"Outputs the version of the application"`
 
-	Id           string `long:"id" description:"Jailer VMM id"`
-	ExecFile     string `long:"exec-file" description:"Jailer executable"`
-	JailerBinary string `long:"jailer" description:"Jailer binary"`
+	Id            string `long:"id" description:"Jailer VMM id"`
+	ExecFile      string `long:"exec-file" description:"Jailer executable"`
+	JailerBinary  string `long:"jailer" description:"Jailer binary"`
+	CgroupVersion int    `long:"cgroup-version" description:"Cgroup version to use" default:"1"`
 
 	Uid      int `long:"uid" description:"Jailer uid for dropping privileges"`
 	Gid      int `long:"gid" description:"Jailer gid for dropping privileges"`
@@ -125,6 +126,7 @@ func (opts *options) getFirecrackerConfig() (firecracker.Config, error) {
 			Stdout:         os.Stdout,
 			Stderr:         os.Stderr,
 			Stdin:          os.Stdin,
+			CgroupVersion:  strconv.Itoa(opts.CgroupVersion),
 		}
 	} else {
 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Firecracker jails support cgroups v2, but this cannot be specified from `firectl`.

This patch allows specifying the version, and defaults to v1 - so as not to break any existing scripts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
