### PR TITLE
Update documentation for contacting maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,5 +136,4 @@ users or developers of this software, please do not report it using
 GitHub issues, but instead follow
 [Firecracker's security reporting guidelines](https://github.com/firecracker-microvm/firecracker/blob/main/SECURITY.md).
 
-Other discussion: For general discussion, please join us in the
-`#general` channel on the [Firecracker Slack](https://tinyurl.com/firecracker-microvm).
+Other discussion: For general discussion, please get in touch with the [Firecracker community.](https://github.com/firecracker-microvm/firecracker?tab=readme-ov-file#faq--contact).


### PR DESCRIPTION
*Issue #, if available:*

Alternative to #107. (Thanks @codyro; apologies for the delay)

*Description of changes:*
This change updates the README to point to firecracker repository README contact section which is kept up-to-date.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
