### PR TITLE
Bump Go min to Go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.21', '1.22']
+        go: ['1.23', '1.24']
         os: ['ubuntu-20.04', 'ubuntu-22.04']
 
     name: ${{ matrix.os }} / Go ${{ matrix.go }}

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 build-in-docker:
-	docker run --rm -v $(CURDIR):/firectl --workdir /firectl golang:1.22 make
+	docker run --rm -v $(CURDIR):/firectl --workdir /firectl golang:1.23 make
 
 test:
 	go test -v ./...
@@ -47,7 +47,7 @@ lint: $(deps)
 	$(BINPATH)/golangci-lint run
 
 $(BINPATH)/golangci-lint:
-	GOBIN=$(BINPATH) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2
+	GOBIN=$(BINPATH) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
 	$(BINPATH)/golangci-lint --version
 
 $(BINPATH)/git-validation:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Building
 The default Makefile rule executes `go build` and relies on the Go toolchain
 installed on your computer.
 _We use [go modules](https://github.com/golang/go/wiki/Modules), and building
-requires Go 1.14 or newer._
+requires Go 1.23 or newer._
 
 If you do not have a new-enough Go toolchain installed, you can use `make
 build-in-docker`.  This rule creates a temporary Docker container which builds

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/firecracker-microvm/firectl
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change bumps Go min in go.mod and CI to Go 1.23 to unblock dependabot PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
