### PR TITLE
ci: update github actions runner images

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,9 @@ jobs:
     strategy:
       matrix:
         go: ['1.23', '1.24']
-        os: ['ubuntu-20.04', 'ubuntu-22.04']
 
-    name: ${{ matrix.os }} / Go ${{ matrix.go }}
-    runs-on: ${{ matrix.os }}
+    name: Go ${{ matrix.go }}
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3


### PR DESCRIPTION
*Issue #, if available:*
Ubuntu 20 GitHub Actions runners are no longer supported.

*Description of changes:*
This change runs GitHub Actions on Ubuntu latest runners. The firectl CI is minimalistic and not very prone to failures from VM updates. It should be fine to give up a little bit of build reproducibility for less maintenance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
